### PR TITLE
Add gitignore description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Optional eslint cache
 .eslintcache


### PR DESCRIPTION
We missed description comment for .eslintcache. Adding comment for completion.